### PR TITLE
Redo loading - get_data_properties() instead of 3 separate functions

### DIFF
--- a/loading.py
+++ b/loading.py
@@ -34,64 +34,36 @@ def get_coordinates(data):
     return coordinates
 
 
-def get_paths(data):
+def get_data_properties(data):
     """
-    Get paths to tiles images.
+    Get significant data from JSON file fields.
 
-    data: a dict created from decoded Tiled 1.2 JSON file
-
-    Return a dictionary with modified tile ID as a key and path to file
-    of the image as a value.
-
-    Create a dictionary where tile ID is modified with the number of the
-    tileset used in Tiled 1.2, so it matches the tile number in the tilelist.
+    Take data - raw JSON input and get tile types, paths to images
+    and tile's custom properties.
     """
-    paths = {}
-    for json_tile in data['tilesets'][0]['tiles']:
-        id = json_tile['id'] + data['tilesets'][0]['firstgid']
-        path = json_tile['image']
-        path = path[1:]  # unelegant way of removing ../ at the beginning of the path
-        paths[id] = path
-    return paths
-
-
-def get_types(data):
-    """
-    Get tile types.
-
-    data: a dict created from decoded Tiled 1.2 JSON file
-
-    Return a dictionary with modified tile ID as a key and type of tile as a value.
-    """
-    types = {}
-    for json_tile in data['tilesets'][0]['tiles']:
-        id = json_tile['id'] + data['tilesets'][0]['firstgid']
-        types[id] = json_tile['type']
-    return types
-
-
-def get_properties(data):
-    """
-    Get tile properties.
-
-    data: a dict created from decoded Tiled 1.2 JSON file
-
-    Return a dictionary with modified tile ID as a key
-    and properties of tile as a value.
-
-    Except for ground, hole, wall and starting tile. These tiles don't have
-    custom properties, so their properties are empty lists.
-    """
-    types = get_types(data)
-    properties = {}
     no_properties_tiles = {'ground', 'hole', 'wall', 'starting_square'}
+    types = {}
+    properties = {}
+    paths = {}
+
     for json_tile in data['tilesets'][0]['tiles']:
         id = json_tile['id'] + data['tilesets'][0]['firstgid']
+
+        #types as 'hole', 'pusher'
+        types[id] = json_tile['type']
+
+        #custom properties
         if types[id] not in no_properties_tiles:
             properties[id] = json_tile['properties']
         else:
             properties[id] = []
-    return properties
+
+        #paths to tile image
+        path = json_tile['image']
+        path = path[1:]  # unelegant way of removing ../ at the beginning of the path
+        paths[id] = path
+
+    return types, properties, paths
 
 
 def get_tile_id(tile_number):
@@ -133,10 +105,8 @@ def get_board(map_name):
     https://www.geeksforgeeks.org/python-dictionary-comprehension/
     """
     data = get_data(map_name)
-    paths = get_paths(data)
+    types, properties, paths = get_data_properties(data)
     coordinates = get_coordinates(data)
-    types = get_types(data)
-    properties = get_properties(data)
 
     # create dictionary of coordinates where value is empty list for further transformation
     board = {coordinate: [] for coordinate in coordinates}

--- a/test_backend.py
+++ b/test_backend.py
@@ -1,6 +1,6 @@
 from backend import  get_starting_coordinates, get_robot_paths, get_robots_to_start, get_start_state, Robot, State
 from util import Tile, HoleTile, WallTile, GearTile, PusherTile, LaserTile, StartTile, Direction
-from loading import get_coordinates, get_data, get_tile_id, get_tile_direction, get_board, get_paths
+from loading import get_coordinates, get_data, get_tile_id, get_tile_direction, get_board, get_data_properties
 from pathlib import Path
 from validator import check_squares
 import pytest
@@ -136,19 +136,6 @@ def test_convert_tile_direction(tile_number, converted_number):
     transformed to valid direction in degrees.
     """
     assert get_tile_direction(tile_number) == converted_number
-
-
-def test_dict_paths_is_correct():
-    """
-    Assert that the result of get_paths() is a dictionary.
-    Assert that the paths structure is valid: integer is tile ID, string is path to the picture.
-    """
-    data = get_data("maps/test_3.json")
-    paths = get_paths(data)
-    for key, value in paths.items():
-        assert isinstance(key, int)
-        assert isinstance(value, str)
-    assert isinstance(paths, dict)
 
 
 def test_robots_on_starting_coordinates():


### PR DESCRIPTION
Solves: #141 
Reimplementation with the same functionality. Instead of three functions getting various properties, one which in single for cycle does the same and returns data we want. Deleted test which was checking the removed part of code.