### PR TITLE
Edit Direction class and rework usage of Direction and Rotation classes in tiles' effects

### DIFF
--- a/game.py
+++ b/game.py
@@ -7,7 +7,7 @@ The game module
 import pyglet
 import sys
 
-from backend import get_start_state, play_the_game
+from backend import get_start_state, apply_all_effects
 from frontend import create_window, draw_state
 
 
@@ -43,7 +43,7 @@ def move_once(t):
     Move all robots according to mock cards on hand and perform tile effects.
     """
 
-    play_the_game(state)
+    apply_all_effects(state)
     print("After tile effects:")
     for robot in state.robots:
         print(robot)

--- a/maps/development_tileset.json
+++ b/maps/development_tileset.json
@@ -71,7 +71,7 @@
                 {
                  "name":"move_direction",
                  "type":"int",
-                 "value":1
+                 "value":90
                 }],
          "type":"gear"
         },
@@ -84,7 +84,7 @@
                 {
                  "name":"move_direction",
                  "type":"int",
-                 "value":-1
+                 "value":-90
                 }],
          "type":"gear"
         },
@@ -220,7 +220,7 @@
                 {
                  "name":"direction_out",
                  "type":"int",
-                 "value":-1
+                 "value":-90
                 },
                 {
                  "name":"express",
@@ -238,7 +238,7 @@
                 {
                  "name":"direction_out",
                  "type":"int",
-                 "value":1
+                 "value":90
                 },
                 {
                  "name":"express",
@@ -256,7 +256,7 @@
                 {
                  "name":"direction_out",
                  "type":"int",
-                 "value":-1
+                 "value":-90
                 },
                 {
                  "name":"express",
@@ -274,7 +274,7 @@
                 {
                  "name":"direction_out",
                  "type":"int",
-                 "value":1
+                 "value":90
                 },
                 {
                  "name":"express",
@@ -292,7 +292,7 @@
                 {
                  "name":"direction_out",
                  "type":"int",
-                 "value":2
+                 "value":180
                 },
                 {
                  "name":"express",
@@ -328,7 +328,7 @@
                 {
                  "name":"direction_out",
                  "type":"int",
-                 "value":1
+                 "value":90
                 },
                 {
                  "name":"express",
@@ -346,7 +346,7 @@
                 {
                  "name":"direction_out",
                  "type":"int",
-                 "value":-1
+                 "value":-90
                 },
                 {
                  "name":"express",
@@ -364,7 +364,7 @@
                 {
                  "name":"direction_out",
                  "type":"int",
-                 "value":-1
+                 "value":-90
                 },
                 {
                  "name":"express",
@@ -382,7 +382,7 @@
                 {
                  "name":"direction_out",
                  "type":"int",
-                 "value":1
+                 "value":90
                 },
                 {
                  "name":"express",
@@ -400,7 +400,7 @@
                 {
                  "name":"direction_out",
                  "type":"int",
-                 "value":2
+                 "value":180
                 },
                 {
                  "name":"express",
@@ -642,7 +642,7 @@
                  "value":8
                 }],
          "type":"start"
-        }, 
+        },
         {
          "id":47,
          "image":"..\/img\/tiles\/png\/stop_tile01.png",
@@ -655,7 +655,7 @@
                  "value":1
                 }],
          "type":"stop"
-        }, 
+        },
         {
          "id":48,
          "image":"..\/img\/tiles\/png\/stop_tile02.png",
@@ -668,7 +668,7 @@
                  "value":2
                 }],
          "type":"stop"
-        }, 
+        },
         {
          "id":49,
          "image":"..\/img\/tiles\/png\/stop_tile03.png",
@@ -681,7 +681,7 @@
                  "value":3
                 }],
          "type":"stop"
-        }, 
+        },
         {
          "id":50,
          "image":"..\/img\/tiles\/png\/stop_tile04.png",
@@ -694,7 +694,7 @@
                  "value":4
                 }],
          "type":"stop"
-        }, 
+        },
         {
          "id":51,
          "image":"..\/img\/tiles\/png\/stop_tile05.png",
@@ -707,7 +707,7 @@
                  "value":5
                 }],
          "type":"stop"
-        }, 
+        },
         {
          "id":52,
          "image":"..\/img\/tiles\/png\/stop_tile06.png",
@@ -720,7 +720,7 @@
                  "value":6
                 }],
          "type":"stop"
-        }, 
+        },
         {
          "id":53,
          "image":"..\/img\/tiles\/png\/stop_tile07.png",
@@ -733,7 +733,7 @@
                  "value":7
                 }],
          "type":"stop"
-        }, 
+        },
         {
          "id":54,
          "image":"..\/img\/tiles\/png\/stop_tile08.png",

--- a/test_backend.py
+++ b/test_backend.py
@@ -201,10 +201,10 @@ def test_robot_changed_start_coordinates(tile, coordinates_after):
 # GearTile
 
 @pytest.mark.parametrize(("direction_before", "tile", "direction_after"),
-                         [(Direction.E, GearTile(None, None, {'move_direction': -1}),  Direction.N),
-                         (Direction.E, GearTile(None, None, {'move_direction': 1}), Direction.S),
-                         (Direction.S, GearTile(None, None, {'move_direction': -1}), Direction.E),
-                         (Direction.S, GearTile(None, None, {'move_direction': 1}), Direction.W),
+                         [(Direction.E, GearTile(None, None, {'move_direction': -90}),  Direction.N),
+                         (Direction.E, GearTile(None, None, {'move_direction': 90}), Direction.S),
+                         (Direction.S, GearTile(None, None, {'move_direction': -90}), Direction.E),
+                         (Direction.S, GearTile(None, None, {'move_direction': 90}), Direction.W),
                           ])
 def test_robot_changed_direction(direction_before, tile, direction_after):
     """

--- a/test_loading.py
+++ b/test_loading.py
@@ -112,7 +112,7 @@ def test_board_structure():
         (2, "hole", {}),
         (13, "wall", {}),
         (4, "laser", {"laser_strength": 1, "laser_start": False}),
-        (7, "gear", {"move_direction": 1}),
+        (7, "gear", {"move_direction": 90}),
         (10, "pusher", {"register": 1}),
         (24, "belt", {"direction_out": 0, "express": True}),
     ]

--- a/tile.py
+++ b/tile.py
@@ -156,7 +156,10 @@ class HoleTile(Tile):
 
 class BeltTile(Tile):
     def __init__(self, direction, path, properties):
-        self.direction_out = transform_direction(properties["direction_out"])
+        if properties["direction_out"] == 0:
+            self.direction_out = Direction.N
+        else:
+            self.direction_out = Rotation(properties["direction_out"])
         self.express = properties["express"]
         super().__init__(direction, path, properties)
 
@@ -201,7 +204,7 @@ class PusherTile(Tile):
 
 class GearTile(Tile):
     def __init__(self, direction, path, properties):
-        self.move_direction = transform_direction(properties["move_direction"])
+        self.move_direction = Rotation(properties["move_direction"])
         super().__init__(direction, path, properties)
 
     def rotate_robot(self, robot):
@@ -291,18 +294,3 @@ def create_tile_subclass(direction, path, type, properties):
     Create tile subclass according to its type.
     """
     return TILE_CLS[type](direction, path, properties)
-
-
-def transform_direction(direction_int):
-    """
-    Function to transform the string taken from json properties to valid
-    Rotation class instance for later processing.
-    """
-    if direction_int == 0:
-        return Direction.N
-    if direction_int == -1:
-        return Rotation.LEFT
-    if direction_int == 1:
-        return Rotation.RIGHT
-    if direction_int == 2:
-        return Rotation.U_TURN

--- a/util.py
+++ b/util.py
@@ -6,12 +6,12 @@ from enum import Enum
 
 
 class Direction(Enum):
-    N = 0, (0, +1), 0
-    E = 90, (+1, 0), 1
-    S = 180, (0, -1), 2
-    W = 270, (-1, 0), 3
+    N = 0, (0, +1)
+    E = 90, (+1, 0)
+    S = 180, (0, -1)
+    W = 270, (-1, 0)
 
-    def __new__(cls, degrees, coor_delta, tile_property):
+    def __new__(cls, degrees, coor_delta):
         """
         Get attributes value and vector of the given Direction class values.
 
@@ -29,7 +29,6 @@ class Direction(Enum):
         obj = object.__new__(cls)
         obj._value_ = degrees
         obj.coor_delta = coor_delta
-        obj.map_property = tile_property
         return obj
 
     def __add__(self, other):


### PR DESCRIPTION
#233 
- Delete `map_property` from `Direction` class.
- Edit values of tiles properties related to changes of direction.
- Delete `transform_direction` function from `tile.py`. Instead use `Direction`/`Rotation` classes directly.

- Fix `game.py` module.