### PR TITLE
Server doesnt wait for msg from client receiver

### DIFF
--- a/client_interface.py
+++ b/client_interface.py
@@ -59,8 +59,6 @@ class Interface:
                         else:
                             print(msg.data)
 
-
-
         self.ws = None
 
 def tick_asyncio(dt):

--- a/client_interface.py
+++ b/client_interface.py
@@ -8,64 +8,64 @@ import pyglet
 
 from interface_frontend import draw_interface, create_window, handle_text
 from interface import get_interface_state
+from backend import State
 
+class Interface:
+    def __init__(self):
+        self.window = create_window()
+        self.window.push_handlers(on_draw=self.window_draw, on_text=self.on_text)
+        self.state = get_interface_state()
+        self.ws = None
 
-state = get_interface_state()
-window = create_window()
+    def window_draw(self):
+        self.window.clear()
+        draw_interface(self.state, self.window)
 
-ws = None
+    def on_text(self, text):
+        """
+        Key listener.
+        Wait for user input on keyboard and react for it.
+        """
+        handle_text(self.state, text)
+        self.send_to_server(self.state)
 
+    def send_to_server(self, state):
+        """
+        Client sends selected cards to server.
+        """
+        msg = json.dumps(self.state.my_program)
+        print(msg)
+        if self.ws:
+            asyncio.ensure_future(self.ws.send_str(msg))
 
-@window.event
-def on_draw():
-    """
-    Draw the interface state.
-    """
-    window.clear()
-    draw_interface(state, window)
+    async def send_one(self):
+        """
+        Client connects to server and receives messages.
+        """
+        # create Session
+        async with aiohttp.ClientSession() as session:
+            # create Websocket
+            async with session.ws_connect('http://localhost:8080/interface/') as self.ws:
+                async for msg in self.ws:
+                    # Cycle "for" is finished when client disconnect from server
+                    try:
+                        message = msg.json(loads=json.loads)
+                        game_state = State.from_dict(message)
+                        print("State is", game_state)
 
+                        if msg.type == aiohttp.WSMsgType.TEXT:
+                            if msg.data.startswith("robot"):
+                                robot = msg.data
+                                print(robot)
+                            if msg.data.startswith("cards"):
+                                cards = msg.data
+                                print(cards)
+                        
+                    except json.decoder.JSONDecodeError:
+                        if msg.type == aiohttp.WSMsgType.TEXT:
+                            message = msg.data
 
-@window.event
-def on_text(text):
-    """
-    Key listener.
-    Wait for user input on keyboard and react for it.
-    """
-    handle_text(state, text)
-    send_to_server(state)
-
-
-def send_to_server(state):
-    """
-    Client sends selected cards to server.
-    """
-    msg = json.dumps(state.my_program)
-    print(msg)
-    if ws:
-        asyncio.ensure_future(ws.send_str(msg))
-
-
-async def send_one():
-    """
-    Client connects to server and receives messages.
-    """
-    global ws
-    # create Session
-    async with aiohttp.ClientSession() as session:
-        # create Websocket
-        async with session.ws_connect('http://localhost:8080/interface/') as ws:
-            async for msg in ws:
-                # Cycle "for" is finished when client disconnect from server
-                if msg.type == aiohttp.WSMsgType.TEXT:
-                    if msg.data.startswith("robot"):
-                        robot = msg.data
-                        print(robot)
-                    if msg.data.startswith("cards"):
-                        cards = msg.data
-                        print(cards)
-
-        ws = None
-
+        self.ws = None
 
 def tick_asyncio(dt):
     """
@@ -75,6 +75,9 @@ def tick_asyncio(dt):
     loop.run_until_complete(asyncio.sleep(0))
 
 
+interface = Interface()
+
 pyglet.clock.schedule_interval(tick_asyncio, 1/30)
-asyncio.ensure_future(send_one())
+asyncio.ensure_future(interface.send_one())
+
 pyglet.app.run()

--- a/client_interface.py
+++ b/client_interface.py
@@ -48,22 +48,16 @@ class Interface:
             async with session.ws_connect('http://localhost:8080/interface/') as self.ws:
                 async for msg in self.ws:
                     # Cycle "for" is finished when client disconnect from server
-                    try:
-                        message = msg.json(loads=json.loads)
-                        game_state = State.from_dict(message)
-                        print("State is", game_state)
+                    if msg.type == aiohttp.WSMsgType.TEXT:
+                        if msg.data.startswith("robot"):
+                            robot = msg.data
+                            print(robot)
+                        if msg.data.startswith("cards"):
+                            cards = msg.data
+                            print(cards)
+                        else:
+                            print(msg.data)
 
-                        if msg.type == aiohttp.WSMsgType.TEXT:
-                            if msg.data.startswith("robot"):
-                                robot = msg.data
-                                print(robot)
-                            if msg.data.startswith("cards"):
-                                cards = msg.data
-                                print(cards)
-                        
-                    except json.decoder.JSONDecodeError:
-                        if msg.type == aiohttp.WSMsgType.TEXT:
-                            message = msg.data
 
         self.ws = None
 

--- a/server.py
+++ b/server.py
@@ -62,13 +62,7 @@ async def receiver(request):
 
         # Process messages from this client
         async for msg in ws:
-            if msg.type == aiohttp.WSMsgType.TEXT:
-                print(msg.data)
-
-                # Send messages to all connected clients
-                for client in ws_receivers:
-                    # send info about state
-                    await client.send_str(json.dumps(state.as_dict(map_name)))
+            pass
         return ws
 
 
@@ -85,7 +79,8 @@ async def interface(request):
                 print(msg.data)
 
                 # Send messages to all connected clients
-                for client in ws_interfaces:
+                ws_all = ws_receivers + ws_interfaces
+                for client in ws_all:
                     # send info about state
                     await client.send_str(json.dumps(state.as_dict(map_name)))
         return ws

--- a/server.py
+++ b/server.py
@@ -56,10 +56,7 @@ async def ws_handler(request, ws_list):
 async def receiver(request):
     async with ws_handler(request, ws_receivers) as ws:
         # This message is sent only this (just connected) client
-        # await ws.send_str(robots[0])
         await ws.send_json(state.as_dict(map_name), dumps=json.dumps)
-        # await ws.send_str(card_pack)
-
         # Process messages from this client
         async for msg in ws:
             pass
@@ -70,19 +67,18 @@ async def receiver(request):
 async def interface(request):
     async with ws_handler(request, ws_interfaces) as ws:
         # This message is sent only this (just connected) client
-        await ws.send_str(f"robot, {robots[0]}")
-        # await ws.send_json(state.as_dict(map_name), dumps=json.dumps)
-        await ws.send_str(f"cards, {card_pack}")
+        await ws.send_json(robots[0], dumps=json.dumps)
+        await ws.send_json(state.as_dict(map_name), dumps=json.dumps)
+        await ws.send_json(card_pack, dumps=json.dumps)
         # Process messages from this client
         async for msg in ws:
             if msg.type == aiohttp.WSMsgType.TEXT:
                 print(msg.data)
-
                 # Send messages to all connected clients
                 ws_all = ws_receivers + ws_interfaces
                 for client in ws_all:
                     # send info about state
-                    await client.send_str(json.dumps(state.as_dict(map_name)))
+                    await client.send_json(state.as_dict(map_name), dumps=json.dumps)
         return ws
 
 


### PR DESCRIPTION
Server už nečeká na zprávy od client_receiver, takže smazán obsah toho cyklu
Dále jsem upravila v serveru v routu u interface aby se stav posílal všem klientům, protože když se spustil interface a mačkaly se klávesy, tak ani jeden nic neobdržel.
Zprávy v client_interface.py se potom budou dál upravovat, jen jsem chtěla aby to "fungovalo" - obdržel stav.