### PR TITLE
Server assings robot to client_interface

### DIFF
--- a/server.py
+++ b/server.py
@@ -29,7 +29,11 @@ state = get_start_state(map_name)
 
 card_pack = create_card_pack()
 card_pack = str(card_pack)
-robots = get_robot_names()
+
+available_robots = get_robot_names()
+# Dictionary {ws_interface: robot_name}
+assigned_robots = {}
+
 
 # A list of connected clients
 ws_receivers = []
@@ -45,6 +49,11 @@ async def ws_handler(request, ws_list):
     await ws.prepare(request)
     # WebSocket is added to a list
     ws_list.append(ws)
+    if ws_list == ws_interfaces:
+        assigned_robots[ws] = available_robots[0]
+        available_robots.pop(0)
+        print(assigned_robots)
+        print(available_robots)
     try:
         yield ws
     finally:
@@ -67,9 +76,9 @@ async def receiver(request):
 async def interface(request):
     async with ws_handler(request, ws_interfaces) as ws:
         # This message is sent only this (just connected) client
-        await ws.send_json(robots[0], dumps=json.dumps)
+        #await ws.send_json(robots[0], dumps=json.dumps)
         await ws.send_json(state.as_dict(map_name), dumps=json.dumps)
-        await ws.send_json(card_pack, dumps=json.dumps)
+        #await ws.send_json(card_pack, dumps=json.dumps)
         # Process messages from this client
         async for msg in ws:
             if msg.type == aiohttp.WSMsgType.TEXT:

--- a/server.py
+++ b/server.py
@@ -15,7 +15,7 @@ import contextlib
 import aiohttp
 from aiohttp import web
 
-from backend import get_start_state, get_robot_names
+from backend import get_start_state
 from interface import create_card_pack
 
 
@@ -30,8 +30,8 @@ state = get_start_state(map_name)
 card_pack = create_card_pack()
 card_pack = str(card_pack)
 
-available_robots = get_robot_names()
-# Dictionary {ws_interface: robot_name
+available_robots = state.robots
+# Dictionary {ws_interface: robot_name}
 assigned_robots = {}
 
 

--- a/server.py
+++ b/server.py
@@ -30,7 +30,7 @@ state = State.get_start_state(map_name)
 card_pack = create_card_pack()
 card_pack = str(card_pack)
 
-available_robots = state.robots
+available_robots = list(state.robots)
 # Dictionary {ws_interface: robot_name}
 assigned_robots = {}
 

--- a/server.py
+++ b/server.py
@@ -31,7 +31,7 @@ card_pack = create_card_pack()
 card_pack = str(card_pack)
 
 available_robots = get_robot_names()
-# Dictionary {ws_interface: robot_name}
+# Dictionary {ws_interface: robot_name
 assigned_robots = {}
 
 
@@ -50,10 +50,9 @@ async def ws_handler(request, ws_list):
     # WebSocket is added to a list
     ws_list.append(ws)
     if ws_list == ws_interfaces:
-        assigned_robots[ws] = available_robots[0]
-        available_robots.pop(0)
+        assigned_robots[ws] = available_robots.pop(0)
         print(assigned_robots)
-        print(available_robots)
+
     try:
         yield ws
     finally:

--- a/server.py
+++ b/server.py
@@ -50,7 +50,8 @@ async def ws_handler(request, ws_list):
     # WebSocket is added to a list
     ws_list.append(ws)
     if ws_list == ws_interfaces:
-        assigned_robots[ws] = available_robots.pop(0)
+        name = available_robots[0].name
+        assigned_robots[name] = available_robots.pop(0)
         print(assigned_robots)
 
     try:

--- a/server.py
+++ b/server.py
@@ -31,7 +31,7 @@ card_pack = create_card_pack()
 card_pack = str(card_pack)
 
 available_robots = list(state.robots)
-# Dictionary {ws_interface: robot_name}
+# Dictionary {robot_name: ws_interface}
 assigned_robots = {}
 
 


### PR DESCRIPTION
Když se připojí client_interface, server mu přiřadí jméno robota. Jde to udělat líp?
Jde to pak nějak rozklíčovat a přiřadit k robotům? Chápu to tak, že roboti se momentálně vytvoří a umístí na hrací plochu, až když se vytvoří stav( `create_robots`)? Nebo je lepší udělat nějaký počáteční seznam přímo robotů, jako už s vlastnostmi, na počátku 3 životy, ale souřadnice None atd...? 