### PR TITLE
Fix game crash caused by apply_register method

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -689,7 +689,8 @@ class State:
         """
         robot_cards = self.get_robots_ordered_by_cards_priority(register)
         for robot, card in robot_cards:
-            card.apply_effect(robot, self)
+            if not robot.inactive:
+                card.apply_effect(robot, self)
 
     def apply_all_effects(self, registers=5):
         """


### PR DESCRIPTION
Fixes #367 
Tak problém nebyl v robotí metodě walk, ale v metodě `apply_register`. V ní je metoda `get_robots_ordered_by_cards_priority`, která sice bere v potaz, zda je robot aktivní a bude hrát v daném registru kartu, ale dál chyběla kontrola, jestli v tom samém registru nedošlo ke změně v aktivitě robotů. 
Typická je situace, kdy robot s vyšší prioritou karty vytlačí robota s kartou nižší priority mimo hrací plochu, následně se pokusí vytlačený robot zahrát svou kartu a hra spadne. Pro jistotu přikládám i chybovou hlášku, kterou jsem dostala.

![apply_register_fix](https://user-images.githubusercontent.com/38920177/65151403-561f1200-da26-11e9-8a4a-9a964f40821e.png)
