### PR TITLE
Vracení neaktivních robotů

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -31,7 +31,7 @@ class Robot:
     def __init__(self, direction, coordinates, name):
         self.direction = direction
         self.coordinates = coordinates
-        self.start_coordinates = coordinates
+        self.start_coordinates = [coordinates]
         self.program = [None, None, None, None, None]
         self.lives = 3
         self.flags = 0
@@ -308,20 +308,19 @@ class Robot:
         self.power_down = True
         self.selection_confirmed = True
 
-    def change_start_coordinates(self, state):
+    def find_free_start(self, state):
         """
-        Check if the other robots have the same starting coordinates as
-        own current coordinates. If so, don't change the starting coordinates.
-        If there is no other robot with the same starting coordinates,
-        change the start coordinates to current ones.
+        Check the start coordinates from the last in the list.
+        If no other robots stand on them, set current coordinates there.
+        If there are robots, check the next until you get the free ones.
         """
-        for robot in state.robots:
-            if robot.start_coordinates == self.coordinates:
-                return
-        else:
-            if self.start_coordinates != self.coordinates:
-                self.start_coordinates = self.coordinates
-                state.record_log()
+        for last_coordinates in reversed(self.start_coordinates):
+            for robot in state.robots:
+                if robot.coordinates == last_coordinates:
+                    break
+            else:
+                self.coordinates = last_coordinates
+                break
 
     def select_blocked_cards_from_program(self):
         """
@@ -715,8 +714,8 @@ class State:
         # Collect flags, repair robots
         for robot in self.get_active_robots():
             for tile in self.get_tiles(robot.coordinates):
-                tile.collect_flag(robot, self)
-                tile.set_new_start(robot, self)
+                tile.collect_flag(robot)
+                tile.set_new_start(robot)
 
     def set_robots_for_new_turn(self):
         """
@@ -728,10 +727,11 @@ class State:
         for robot in self.robots:
             for tile in self.get_tiles(robot.coordinates):
                 tile.repair_robot(robot, self)
-            # Robot will now ressurect at his start coordinates
             if robot.inactive:
-                robot.coordinates = robot.start_coordinates
                 robot.damages = 0
+                # Robot will now ressurect at the first free
+                # start coordinates he stepped on during the game.
+                robot.find_free_start(self)
                 self.record_log()
 
     def get_robots_ordered_by_cards_priority(self, register):
@@ -911,7 +911,7 @@ def get_robot_names():
     return robot_names
 
 
-def get_start_tiles(board, tile_type="start", players=None):
+def get_start_tiles(board, tile_type="start"):
     """
     Get initial tiles for robots. It can be either start or stop tiles.
 
@@ -930,15 +930,11 @@ def get_start_tiles(board, tile_type="start", players=None):
     for coordinate, tiles in board.items():
         for tile in tiles:
             if tile.type == tile_type:
-                if players == None or len(robot_tiles) < players:
-                    robot_tiles[tile.number] = {"coordinates": coordinate,
-                                                "tile_direction": tile.direction}
-                else:
-                    break
+                robot_tiles[tile.number] = {"coordinates": coordinate,
+                                            "tile_direction": tile.direction}
 
     # Sort created dictionary by the first element - start tile number
     robot_tiles = OrderedDict(sorted(robot_tiles.items(), key=lambda stn: stn[0]))
-
     return robot_tiles
 
 
@@ -954,18 +950,21 @@ def create_robots(board, players=None):
     Robots are placed on board in the direction of their start tiles.
     The robots are ordered according to their start tiles.
     """
-    start_tiles = get_start_tiles(board, players=players)
+    start_tiles = get_start_tiles(board)
     robots_on_start = []
     robot_names = get_robot_names()
 
     for start_tile_number, name in zip(start_tiles, robot_names):
-        # Get direction and coordinates for the robot on the tile
-        initial_direction = start_tiles[start_tile_number]["tile_direction"]
-        initial_coordinates = start_tiles[start_tile_number]["coordinates"]
+        if players is not None and len(robots_on_start) >= players:
+            break
+        else:
+            # Get direction and coordinates for the robot on the tile
+            initial_direction = start_tiles[start_tile_number]["tile_direction"]
+            initial_coordinates = start_tiles[start_tile_number]["coordinates"]
 
-        # Create a robot, add him to robot's list
-        robot = Robot(initial_direction, initial_coordinates, name)
-        robots_on_start.append(robot)
+            # Create a robot, add him to robot's list
+            robot = Robot(initial_direction, initial_coordinates, name)
+            robots_on_start.append(robot)
     return robots_on_start
 
 

--- a/server.py
+++ b/server.py
@@ -251,7 +251,7 @@ def get_app(server):
 
 
 @click.command()
-@click.option("-m", "--map-name", default="maps/game_8_1.json",
+@click.option("-m", "--map-name", default="maps/belt_map.json",
               help="Name of the played map.")
 @click.option("-p", "--players", help="Number of players", type=int)
 def main(map_name, players):

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,22 +1,10 @@
 import pytest
 
-from backend import create_robots, Robot, State, MovementCard
+from backend import Robot, State, MovementCard
 from backend import RotationCard, get_direction_from_coordinates
 from backend import get_robot_names
 from util_backend import Direction, Rotation
 from tile import Tile
-from loading import get_board
-
-
-def test_robots_on_start_coordinates():
-    """
-    Assert that the result of create_robots is a list which contains
-    Robot objects with correct attribute coordinates.
-    """
-    board = get_board("maps/test_maps/test_3.json")
-    robots = create_robots(board)
-    assert isinstance(robots, list)
-    assert isinstance(robots[0], Robot)
 
 
 def test_start_state():

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -347,27 +347,25 @@ def test_check_winner_3():
     assert state.robots[1].winner
 
 
-def test_change_robots_start_coordinates():
+def test_find_last_start_coordinates():
     """
-    Assert it is possible to change start coordinates when no other robot
-    has them as their start ones.
-    """
-    state = State.get_start_state("maps/test_maps/test_3.json")
-    state.robots[0].start_coordinates = (5, 5)
-    state.robots[1].start_coordinates = (1, 0)
-    state.robots[1].coordinates = (5, 4)
-    state.robots[1].change_start_coordinates(state)
-    assert state.robots[1].start_coordinates == (5, 4)
-
-
-def test_dont_change_robots_start_coordinates():
-    """
-    Assert it is not possible to change start coordinates when another robot
-    has them as their start ones.
+    Change the coordinates to the last in the list
+    if no one is standing on them.
     """
     state = State.get_start_state("maps/test_maps/test_3.json")
-    state.robots[0].start_coordinates = (5, 5)
-    state.robots[1].start_coordinates = (1, 0)
+    state.robots[0].start_coordinates = [(1, 0), (5, 5)]
+    state.robots[1].coordinates = (1, 0)
+    state.robots[0].find_free_start(state)
+    assert state.robots[0].coordinates == (5, 5)
+
+
+def test_find_another_robots_start_coordinates():
+    """
+    Don't change coordinates to the last ones when another robot
+    stands on them, pick the previous ones.
+    """
+    state = State.get_start_state("maps/test_maps/test_3.json")
+    state.robots[0].start_coordinates = [(3, 2), (1, 0), (5, 5)]
     state.robots[1].coordinates = (5, 5)
-    state.robots[1].change_start_coordinates(state)
-    assert state.robots[1].start_coordinates == (1, 0)
+    state.robots[0].find_free_start(state)
+    assert state.robots[0].coordinates == (1, 0)

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -140,7 +140,12 @@ def compare_results_with_robots(commands, state):
                 if "power_down" in attribute:
                     assert robot.power_down == attribute["power_down"]
                 if "start" in attribute:
-                    assert robot.start_coordinates == tuple(attribute["start"])
+                    start_coordinates = []
+                    for coordinates in attribute["start"]:
+                        print("tu", coordinates)
+                        start_coordinates.append(tuple(coordinates))
+                    print(start_coordinates)
+                    assert robot.start_coordinates == start_coordinates
 
 
 @pytest.mark.parametrize(

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -142,9 +142,7 @@ def compare_results_with_robots(commands, state):
                 if "start" in attribute:
                     start_coordinates = []
                     for coordinates in attribute["start"]:
-                        print("tu", coordinates)
                         start_coordinates.append(tuple(coordinates))
-                    print(start_coordinates)
                     assert robot.start_coordinates == start_coordinates
 
 

--- a/tests/test_flags_1/commands.yaml
+++ b/tests/test_flags_1/commands.yaml
@@ -41,13 +41,21 @@ prerequisites:
 results:
   -
     flags: 3
-    start: [1, 3]
+    start:
+      - [0, 3]
+      - [1, 3]
   -
     flags: 4
-    start: [1, 2]
+    start:
+      - [0, 2]
+      - [1, 2]
   -
     flags: 3
-    start: [1, 1]
+    start:
+      - [2, 1]
+      - [1, 1]
   -
     flags: 0
-    start: [1, 0]
+    start:
+      - [2, 0]
+      - [1, 0]

--- a/tests/test_pushed_out/map.json
+++ b/tests/test_pushed_out/map.json
@@ -1,4 +1,12 @@
-{ "height":2,
+{ "compressionlevel":0,
+ "editorsettings":
+    {
+     "export":
+        {
+         "target":"."
+        }
+    },
+ "height":2,
  "infinite":false,
  "layers":[
         {
@@ -38,7 +46,7 @@
          "y":0
         }, 
         {
-         "data":[0, 0, 48, 0],
+         "data":[0, 0, 0, 48],
          "height":2,
          "id":4,
          "name":"stop1",
@@ -53,7 +61,7 @@
  "nextobjectid":1,
  "orientation":"orthogonal",
  "renderorder":"right-down",
- "tiledversion":"1.2.4",
+ "tiledversion":"1.3.1",
  "tileheight":64,
  "tilesets":[
         {

--- a/tests/test_repair_3/commands.yaml
+++ b/tests/test_repair_3/commands.yaml
@@ -33,10 +33,16 @@ prerequisites:
 results:
   -
     damages: 9
-    start: [1, 2]
+    start:
+      - [0, 2]
+      - [1, 2]
   -
     damages: 8
-    start: [2, 1]
+    start:
+      - [0, 1]
+      - [2, 1]
   -
     damages: 5
-    start: [2, 0]
+    start:
+      - [0, 0]
+      - [2, 0]

--- a/tile.py
+++ b/tile.py
@@ -92,7 +92,7 @@ class Tile:
         """
         return False
 
-    def collect_flag(self, robot, state):
+    def collect_flag(self, robot):
         """
         Collect flag by robot and change robot's start coordinates.
         """
@@ -104,7 +104,7 @@ class Tile:
         """
         return False
 
-    def set_new_start(self, robot, state):
+    def set_new_start(self, robot):
         """
         Change robot's start coordinates, if possible by tile properties.
         """
@@ -144,6 +144,7 @@ class HoleTile(Tile):
         # Call robot's method for dying.
         robot.die(state)
         return robot
+
 
 class BeltTile(Tile):
     def __init__(self, direction, name, tile_type, properties):
@@ -192,6 +193,7 @@ class PusherTile(Tile):
         if (register + 1) % 2 == self.register:
             robot.move(self.direction.get_new_direction(Rotation.U_TURN), 1, state)
             return True
+
 
 class GearTile(Tile):
     def __init__(self, direction, name, tile_type, properties):
@@ -251,10 +253,10 @@ class FlagTile(Tile):
         self.number = properties["number"]
         super().__init__(direction, name, tile_type, properties)
 
-    def collect_flag(self, robot, state):
+    def collect_flag(self, robot):
         # Robot always changes his start coordinates, when he is on a flag.
         # Flag number doesn't play a role.
-        robot.change_start_coordinates(state)
+        robot.start_coordinates.append(robot.coordinates)
         # Collect only correct flag.
         # Correct flag will have a number that is equal to robot's flag number plus one.
         if (robot.flags + 1) == self.number:
@@ -274,10 +276,10 @@ class RepairTile(Tile):
             state.record_log()
             return True
 
-    def set_new_start(self, robot, state):
+    def set_new_start(self, robot):
         # Change start coordinates of robot, if it's a tile property.
         if self.new_start:
-            robot.change_start_coordinates(state)
+            robot.start_coordinates.append(robot.coordinates)
             return True
 
 


### PR DESCRIPTION
Fixes #388 (snad naposled)
- roboti si teď drží seznam svých startovacích políček (=těch, na které šlapnuli).
- stav hry si na začátku uloží seznam koordinát všech startovacích políček. 
Pokud robot bude zabit, seznam startovacích políček se obrátí (čteme od nejméně vzdáleného políčka), a přidají se na konec všechna startovací políčka pro tu hru.
Pak se seznam postupně prochází oproti stávajícím koordinatům ostatních robotů. 
Až se najdou první volné, robot se na nich objeví.

To chtělo trochu poupravit testy, vracím teď z `create_robots` dodatečně seznam dvojic se startovacími políčky.
Opravila jsem dva bugy: 
- mapa použitá v serveru jako výchozí neexistovala.
- roboti po přidání players začínali hru na prvních dvou políčkách z levého kraje. Teď zase začínají od políčka s číslem 1.